### PR TITLE
Fixed yaml example of "Migrating to sqlc-gen-kotlin" page

### DIFF
--- a/docs/guides/migrating-to-sqlc-gen-kotlin.md
+++ b/docs/guides/migrating-to-sqlc-gen-kotlin.md
@@ -33,7 +33,7 @@ already. Add the following configuration for the plugin:
 ```yaml
 version: "2"
 plugins:
-  name: "kt"
+- name: "kt"
   wasm:
     url: "https://downloads.sqlc.dev/plugin/sqlc-gen-kotlin_1.0.0.wasm"
     sha256: "7620dc5d462de41fdc90e2011232c842117b416c98fd5c163d27c5738431a45c"


### PR DESCRIPTION

- "plugins" field takes "List" type not "Map".
- The example of the page written in different type, so I fixed example of setting